### PR TITLE
Add Github Actions and Expose Cell Neighbors

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -9,9 +9,9 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
-      - uses: mymindstorm/setup-emsdk@v11
+      - uses: mymindstorm/setup-emsdk@v14
 
       - name: Verify Emscripten is Installed
         run: emcc -v
@@ -23,7 +23,7 @@ jobs:
           ./build.sh
 
       - name: Linux - Upload Build
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         if: runner.os == 'Linux'
         with:
           name: Voro-Emscripten

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,0 +1,32 @@
+name: Build Voro-Emscripten
+
+on:
+  pull_request:
+  push:
+
+jobs:
+  Build:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v3
+
+      - uses: mymindstorm/setup-emsdk@v11
+
+      - name: Verify Emscripten is Installed
+        run: emcc -v
+
+      - name: Linux - Build Base Binary
+        if: runner.os == 'Linux'
+        run: |
+          mkdir bin
+          ./build.sh
+
+      - name: Linux - Upload Build
+        uses: actions/upload-artifact@v3
+        if: runner.os == 'Linux'
+        with:
+          name: Voro-Emscripten
+          path: |
+            ./README.md
+            ./bin

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -18,9 +18,7 @@ jobs:
 
       - name: Linux - Build Base Binary
         if: runner.os == 'Linux'
-        run: |
-          mkdir bin
-          ./build.sh
+        run: ./build.sh
 
       - name: Linux - Upload Build
         uses: actions/upload-artifact@v4

--- a/build.sh
+++ b/build.sh
@@ -9,6 +9,6 @@ emcc\
   -s TOTAL_MEMORY=256MB\
   -s ALLOW_MEMORY_GROWTH=1\
   -Os\
-  --embind-emit-tsd ./voro_raw.d.ts\
+  --emit-tsd ./voro_raw.d.ts\
   -o ./bin/voro_raw.js\
   ./src/embindings.cc ./src/voro++.cc

--- a/src/cell_export.hh
+++ b/src/cell_export.hh
@@ -9,4 +9,5 @@ struct CellExport {
   int nFaces;
   std::vector<float> vertices;
   std::vector<std::vector<int>> faces;
+  std::vector<int> neighbors;
 };

--- a/src/container.hh
+++ b/src/container.hh
@@ -429,7 +429,7 @@ class container : public container_base, public radius_mono {
 		void compute_cell_data(std::vector<CellExport>& cells, bool convertToWorld) {
 			int ijk,q;double *pp;
 			c_loop_all vl(*this);
-			voronoicell c;
+			voronoicell_neighbor c;
 			if(vl.start()) do if(compute_cell(c,vl)) {
 				ijk=vl.ijk;q=vl.q;pp=p[ijk]+ps*q;
 
@@ -454,7 +454,10 @@ class container : public container_base, public radius_mono {
 					fvi += n_corners;
 				}
 
-				cells.push_back({id[ijk][q], float(*pp), float(pp[1]), float(pp[2]), n_faces, verts, faces});
+				std::vector<int> neighbors;
+				c.neighbors(neighbors);
+
+				cells.push_back({id[ijk][q], float(*pp), float(pp[1]), float(pp[2]), n_faces, verts, faces, neighbors});
 			} while(vl.inc());
 		}
 		/** Computes the Voronoi cells and saves customized information

--- a/src/embindings.cc
+++ b/src/embindings.cc
@@ -54,7 +54,8 @@ EMSCRIPTEN_BINDINGS(vorojs) {
       .property("z", &CellExport::z)
       .property("nFaces", &CellExport::nFaces)
       .property("vertices", &CellExport::vertices)
-      .property("faces", &CellExport::faces);
+      .property("faces", &CellExport::faces)
+      .property("neighbors", &CellExport::neighbors);
   emscripten::class_<Container>("Container")
       .constructor<>()
       .constructor<float, float, float, float, float, float, int, int, int>()


### PR DESCRIPTION
This PR adds Continuous Integration via Github Actions to put a green checkmark beside every successfully building commit. 

(And also because I don't like setting up Emscripten locally on my Windows box, so pulling the build from the artifacts is easier)

This also updates the `--embind-emit-tsd` arg to simply `--emit-tsd` to suppress the deprecation warning.

This PR also exposes voronoi neighbors from within Voro++ to make it easier to use this library for tetrahedralization; this is exposed in Voro3D here: https://github.com/LukPopp0/voro3d/pull/1


Hoping this will be a good jumping off point to expose more advanced functionality from Voro++ for [this hobby project](https://github.com/zalo/StochasticLatticeGen).